### PR TITLE
use operator 'in' instead of _.has

### DIFF
--- a/chai-properties.js
+++ b/chai-properties.js
@@ -42,7 +42,7 @@
     function check(testDescr, testVal) {
       try {
         return _.every(testDescr, function (val, attr) {
-          if (!_.has(testVal, attr)) {
+          if (!(attr in testVal)) {
             throw new Error('No ' + attr + ' in ' + inspect(testVal));
           }
 


### PR DESCRIPTION
We want to peruse in the prototype too. This is very useful for getter & setters.