### PR TITLE
upgade lodash to mitigate vulnerabilities on lodash < 4.17.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,8 @@
     "properties"
   ],
   "dependencies": {
-    "lodash": "^3.1.0"
-  }, 
+    "lodash": "^4.17.15"
+  },
   "license": "MIT",
   "ignore": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "npm": ">= 1.2"
   },
   "dependencies": {
-    "lodash": "~3.1.0"
+    "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
I'm using chai-properties in a project and Github says that we are using a vulnerable version of lodash.
Turns out chai-properties in one the the dependencies using an outdated version of lodash.
This PR improves chai-properties to use a newer version.
Tests are passing.